### PR TITLE
Bump openvino command script version, use remote-build for arm64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,6 @@ adopt-info: gimp-plugins
 
 platforms:
   arm64:
-    build-on: [amd64]
   amd64:
 
 # the recommended mountpoint for the content is /openvino-ai-plugins-gimp
@@ -149,7 +148,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2024.6.0-0
+    source-tag: 2024.6.0-1
     stage:
       - command-chain/openvino-launch
 


### PR DESCRIPTION
For the `arm64` build, I moved away from cross-compiling from a `amd64` host to instead building natively from a `arm64` host. This is possible using `snapcraft remote-build`, which sends jobs to the Launchpad build far.