### PR TITLE
Fix weights directory path when gimp invoked

### DIFF
--- a/command-chain/openvino-ai-plugins-gimp-launch
+++ b/command-chain/openvino-ai-plugins-gimp-launch
@@ -13,11 +13,9 @@ if [ "${SNAP_NAME}" != "openvino-ai-plugins-gimp" ]; then
   export LD_LIBRARY_PATH="${CONTENT_PATH}"/usr/lib/x86_64-linux-gnu:"${SNAP}"/openvino-ai-plugins-gimp/usr/local/lib:"${LD_LIBRARY_PATH}"
   export PYTHONPATH="${CONTENT_PATH}"/lib/python3.12/site-packages:"${PYTHONPATH}"
   export OCL_ICD_VENDORS="${CONTENT_PATH}"/etc/OpenCL/vendors
-  # expected location is $SNAP/openvino-ai-plugins-gimp/weights
-  weights_dir=$(find "${SNAP}" -maxdepth 2 -name weights)
+  weights_dir="${SNAP}"/openvino-ai-plugins-gimp/weights
 else
-  # expected location is $SNAP/weights
-  weights_dir=$(find "${SNAP}" -maxdepth 1 -name weights)
+  weights_dir="${SNAP}"/weights
 fi
 
 # dependency for model_setup.py

--- a/command-chain/openvino-ai-plugins-gimp-launch
+++ b/command-chain/openvino-ai-plugins-gimp-launch
@@ -13,6 +13,11 @@ if [ "${SNAP_NAME}" != "openvino-ai-plugins-gimp" ]; then
   export LD_LIBRARY_PATH="${CONTENT_PATH}"/usr/lib/x86_64-linux-gnu:"${SNAP}"/openvino-ai-plugins-gimp/usr/local/lib:"${LD_LIBRARY_PATH}"
   export PYTHONPATH="${CONTENT_PATH}"/lib/python3.12/site-packages:"${PYTHONPATH}"
   export OCL_ICD_VENDORS="${CONTENT_PATH}"/etc/OpenCL/vendors
+  # expected location is $SNAP/openvino-ai-plugins-gimp/weights
+  weights_dir=$(find "${SNAP}" -maxdepth 2 -name weights)
+else
+  # expected location is $SNAP/weights
+  weights_dir=$(find "${SNAP}" -maxdepth 1 -name weights)
 fi
 
 # dependency for model_setup.py
@@ -20,10 +25,9 @@ mkdir -p "${GIMP_OPENVINO_MODELS_PATH}"/{weights,mms_tmp}
 
 echo "[OpenVINO AI Plugins for GIMP]: Installing super resolution and semantic segmentation models to ${GIMP_OPENVINO_MODELS_PATH} and config to ${GIMP_OPENVINO_CONFIG_PATH}"
 
-# Copy superresolution and semseg models to OV_MODEL_PATH/weights and generate config file
+# Copy super resolution and semseg models to $GIMP_OPENVINO_MODELS_PATH/weights and generate config file
 # Note we force success and suppress output because the script attempts (and fails) to
 # adjust permissions on files inside the snap
-weights_dir=$(find "${SNAP}" -maxdepth 1 -name weights)
 python3 -c "from gimpopenvino import complete_install; complete_install.setup_python_weights(install_location=r'${GIMP_OPENVINO_MODELS_PATH}', repo_weights_dir=r'${weights_dir}')" >/dev/null 2>&1 || true
 
 exec "$@"


### PR DESCRIPTION
I discovered a bug during testing where the super resolution and semantic segmentation models are not present if a user never runs `openvino-ai-plugins-gimp.model-setup` prior to launching `gimp`.