### PR TITLE
Updates for supporting GIMP 3.0

### DIFF
--- a/command-chain/openvino-ai-plugins-gimp-launch
+++ b/command-chain/openvino-ai-plugins-gimp-launch
@@ -10,6 +10,7 @@ if [ "${SNAP_NAME}" != "openvino-ai-plugins-gimp" ]; then
   if [ ! -d "${CONTENT_PATH}" ]; then
     echo "Warning: ${CONTENT_PATH} not present inside ${SNAP_NAME} snap. Please connect the content interface at this path."
   fi
+  export PATH="${PATH}":"${CONTENT_PATH}"/usr/bin
   export LD_LIBRARY_PATH="${CONTENT_PATH}"/usr/lib/x86_64-linux-gnu:"${SNAP}"/openvino-ai-plugins-gimp/usr/local/lib:"${LD_LIBRARY_PATH}"
   export PYTHONPATH="${CONTENT_PATH}"/lib/python3.12/site-packages:"${PYTHONPATH}"
   export OCL_ICD_VENDORS="${CONTENT_PATH}"/etc/OpenCL/vendors

--- a/command-chain/openvino-ai-plugins-gimp-launch
+++ b/command-chain/openvino-ai-plugins-gimp-launch
@@ -26,6 +26,6 @@ echo "[OpenVINO AI Plugins for GIMP]: Installing super resolution and semantic s
 # Copy super resolution and semseg models to $GIMP_OPENVINO_MODELS_PATH/weights and generate config file
 # Note we force success and suppress output because the script attempts (and fails) to
 # adjust permissions on files inside the snap
-python3 -c "from gimpopenvino import complete_install; complete_install.setup_python_weights(install_location=r'${GIMP_OPENVINO_MODELS_PATH}', repo_weights_dir=r'${weights_dir}')" >/dev/null 2>&1 || true
+python3 -c "from gimpopenvino import install_utils; install_utils.complete_install(repo_weights_dir=r'${weights_dir}')" >/dev/null 2>&1 || true
 
 exec "$@"

--- a/command-chain/openvino-ai-plugins-gimp-launch
+++ b/command-chain/openvino-ai-plugins-gimp-launch
@@ -14,8 +14,10 @@ if [ "${SNAP_NAME}" != "openvino-ai-plugins-gimp" ]; then
   export LD_LIBRARY_PATH="${CONTENT_PATH}"/usr/lib/x86_64-linux-gnu:"${SNAP}"/openvino-ai-plugins-gimp/usr/local/lib:"${LD_LIBRARY_PATH}"
   export PYTHONPATH="${CONTENT_PATH}"/lib/python3.12/site-packages:"${PYTHONPATH}"
   export OCL_ICD_VENDORS="${CONTENT_PATH}"/etc/OpenCL/vendors
+  export GIT_DIR="${CONTENT_PATH}"/gimp-plugins/.git
   weights_dir="${SNAP}"/openvino-ai-plugins-gimp/weights
 else
+  export GIT_DIR="${SNAP}"/gimp-plugins/.git
   weights_dir="${SNAP}"/weights
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ parts:
       - ./requirements.txt
     override-pull: |
       craftctl default
-      # remove openvino dependency since it has its own part below
+      # remove openvino dependency since it is mounted from content producer snap
       sed -i '/\"openvino\"/d' ./setup.py
       sed -i '/openvino==/d' ./requirements.txt
       craftctl set version="$(git describe --tags --abbrev=4 --always)"
@@ -78,6 +78,9 @@ parts:
       cp -r weights/* ${CRAFT_PART_INSTALL}/weights/
       cp model_setup.py ${CRAFT_PART_INSTALL}
       cp -r gimpopenvino/plugins/* ${CRAFT_PART_INSTALL}/gimp-plugins/
+      chmod +x ${CRAFT_PART_INSTALL}/gimp-plugins/stable_diffusion_ov/stable_diffusion_ov.py
+      chmod +x ${CRAFT_PART_INSTALL}/gimp-plugins/semseg_ov/semseg_ov.py
+      chmod +x ${CRAFT_PART_INSTALL}/gimp-plugins/superresolution_ov/superresolution_ov.py
     stage-packages:
       - python3-minimal # python interpreter
       - python3.12-minimal # python interpreter

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,8 +61,8 @@ apps:
 parts:
   gimp-plugins:
     source-type: git
-    source: https://github.com/frenchwr/openvino-ai-plugins-gimp # TODO: update to upstream
-    source-branch: snap # TODO: update to stable branch once merged
+    source: https://github.com/intel/openvino-ai-plugins-gimp
+    source-tag: 3.0.0
     plugin: python
     python-requirements:
       - ./requirements.txt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,6 +78,8 @@ parts:
       cp -r weights/* ${CRAFT_PART_INSTALL}/weights/
       cp model_setup.py ${CRAFT_PART_INSTALL}
       cp -r gimpopenvino/plugins/* ${CRAFT_PART_INSTALL}/gimp-plugins/
+      # plugins set plugin version from git tags, so copy repo metadata into snap
+      cp -r .git ${CRAFT_PART_INSTALL}/gimp-plugins/
       chmod +x ${CRAFT_PART_INSTALL}/gimp-plugins/stable_diffusion_ov/stable_diffusion_ov.py
       chmod +x ${CRAFT_PART_INSTALL}/gimp-plugins/semseg_ov/semseg_ov.py
       chmod +x ${CRAFT_PART_INSTALL}/gimp-plugins/superresolution_ov/superresolution_ov.py

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,7 @@ parts:
       - libx11-6 # opencv-python dep
       - libxext6 # opencv-python dep
       - libgomp1 # pytorch dep
+      - git # plugin version displayed in GIMP by running "git describe"
     stage:
       - -lib/python3.12/site-packages/torch/lib/libtorchbind_test.so
       - -usr/lib/x86_64-linux-gnu/libGLU.so.1.3.1


### PR DESCRIPTION
This adds support for GIMP 3.0, which was recently added ([link to release](https://github.com/intel/openvino-ai-plugins-gimp/releases/tag/3.0.0)) in the upstream OpenVINO AI Plugins project.

I tested these changes with the GIMP 3.0 RC2 snap on both a Meteor Lake (`hercules`) and Lunar Lake (`tucano`) machine running Ubuntu 24.10.


Internal Jira card: [PEK-1590](https://warthogs.atlassian.net/browse/PEK-1590)

[PEK-1590]: https://warthogs.atlassian.net/browse/PEK-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ