### PR TITLE
Promote grade to stable based on support agreement

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   also provides an application for downloading models that can be
   used with the stable diffusion plugin.
 
-grade: devel
+grade: stable
 confinement: strict
 adopt-info: gimp-plugins
 


### PR DESCRIPTION
Until now the snap has been published in `edge` and `beta` only, this PR will enable us to now also promote to `candidate` and `stable`.