### PR TITLE
Fix paths to model data

### DIFF
--- a/checkbox/checkbox-provider-openvino-ai-plugins-gimp/units/jobs.pxu
+++ b/checkbox/checkbox-provider-openvino-ai-plugins-gimp/units/jobs.pxu
@@ -77,7 +77,7 @@ command:
     >&2 echo "In order to run the GIMP plugin tests you must first remove this file."
     exit 1
   fi
-  MODELS_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp
+  MODELS_DIR=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common
   if [ -d ${MODELS_DIR} ]; then
     >&2 echo "Test failure: ${MODELS_DIR} already exists!"
     >&2 echo "In order to run the GIMP plugin tests you must first remove this directory."
@@ -109,7 +109,7 @@ estimated_duration: 2s
 depends:
   gimp/model_setup_empty_run
 command:
-  SEMSEG_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp/weights/semseg-ov
+  SEMSEG_DIR=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/weights/semseg-ov
   file_cnt=$(ls ${SEMSEG_DIR} | wc -l)
   if [ ${file_cnt} != "5" ]; then
     >&2 echo "Test failure: expected 5 files in ${SEMSEG_DIR}, got ${file_cnt} instead."
@@ -125,7 +125,7 @@ estimated_duration: 2s
 depends:
   gimp/model_setup_empty_run
 command:
-  SUPERRES_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp/weights/superresolution-ov
+  SUPERRES_DIR=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/weights/superresolution-ov
   file_cnt=$(ls ${SUPERRES_DIR} | wc -l)
   if [ ${file_cnt} != "7" ]; then
     >&2 echo "Test failure: expected 7 files in ${SUPERRES_DIR}, got ${file_cnt} instead."

--- a/command-chain/set-runtime-env
+++ b/command-chain/set-runtime-env
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+export GIMP_OPENVINO_CONFIG_PATH="${SNAP_USER_COMMON}"
+export GIMP_OPENVINO_MODELS_PATH="${SNAP_USER_COMMON}"
+
 mkdir -p "${SNAP_USER_COMMON}"/{mms_tmp,weights}
 
-weights_dir="${SNAP_USER_COMMON}/weights"
+weights_dir="${SNAP}/openvino-gimp/weights"
 
 python3 -c "from gimpopenvino import install_utils; install_utils.complete_install(repo_weights_dir=r'${weights_dir}')"
 


### PR DESCRIPTION
Follow up on https://github.com/canonical/openvino-ai-plugins-gimp-snap/pull/18 to fix the `model-setup` command. Model downloads from GIMP itself are still functioning fine, but I missed a few updates to `model-setup` that this PR fixes.