### PR TITLE
feat: CI improvements

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -55,6 +55,22 @@ test_data:
 
     _put attachments/test/set-device-access.sh :/home/ubuntu/set-device-access.sh
 
+    # Run the validation twice:
+    #
+    # Run 1: original debs and kernel from the certified image
+    # Run 2: upgraded debs and kernel, following a reboot
+    #
     _run checkbox-openvino-ai-plugins-gimp.install-full-deps
     _run sudo bash /home/ubuntu/set-device-access.sh
     _run checkbox-openvino-ai-plugins-gimp.test-runner-automated
+    mkdir -p artifacts
+    _get '/home/ubuntu/.local/share/checkbox-ng/*.tar.xz' artifacts/
+
+    _run sudo apt update
+    _run sudo apt -y upgrade
+    _run sudo reboot
+    wait_for_ssh --allow-degraded
+
+    _run sudo bash /home/ubuntu/set-device-access.sh
+    _run checkbox-openvino-ai-plugins-gimp.test-runner-automated
+    _get '/home/ubuntu/.local/share/checkbox-ng/*.tar.xz' artifacts/

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Submit testflinger job
         id: submit
         continue-on-error: true
-        uses: canonical/testflinger/.github/actions/submit@main
+        uses: canonical/testflinger/.github/actions/submit@submit/v1.4.8
         with:
           poll: true
           job-path: ${{ github.workspace }}/job.yaml

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,15 +1,10 @@
 name: Integration tests
 
 on:
-  push:
-    paths:
-      - 'snap/**'
-      - 'command-chain/**'
-      - 'checkbox/bin/**'
-      - 'checkbox/checkbox-provider-openvino-ai-plugins-gimp/**'
-      - 'checkbox/snap/**'
-      - '.github/workflows/integration-tests.yaml'
-      - '.github/testflinger/**'
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
     branches:
       - main
   workflow_dispatch:
@@ -20,6 +15,7 @@ concurrency:
 
 env:
   CHECKBOX_PROVIDER_NAME: checkbox-openvino-ai-plugins-gimp
+  TEST_OBSERVER_URL: https://test-observer-api.canonical.com
 
 jobs:
   build-checkbox-provider:
@@ -27,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Find and parse snapcraft.yaml
         id: snapcraft-yaml
         uses: snapcrafters/ci/parse-snapcraft-yaml@main
@@ -44,29 +40,29 @@ jobs:
         with:
           name: ${{ env.CHECKBOX_PROVIDER_NAME }}
           path: ${{ steps.build.outputs.snap }}
+
   testflinger-validation:
     name: Testflinger Validation
     needs: [build-checkbox-provider]
     runs-on: self-hosted-linux-amd64-noble-private-endpoint-small
+    # Only run if the release workflow completed successfully
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         device:
           # Dell XPS 13 9340 Laptop, Meteor Lake, 24.04
-          - { queue: dell-xps-13-9340-c34051, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
+          - { queue: dell-xps-13-9340-c34051, gen: "MTL", image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
           # Dell Pro Max Tower T2 Desktop, Arrow Lake, 24.04
-          - { queue: dell-pro-max-tower-f0t2250-0ce1-c36197, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04b-proposed/20241220-148/somerville-noble-oem-24.04b-proposed-20241220-148.iso }
+          - { queue: dell-pro-max-tower-f0t2250-0ce1-c36197, gen: "ARL", image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04b-proposed/20241220-148/somerville-noble-oem-24.04b-proposed-20241220-148.iso }
           # Dell XPS 13 9350 Laptop, Lunar Lake, 24.04
-          - { queue: dell-xps-13-9350-c36962, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04c/20250801-32/somerville-noble-oem-24.04c-20250801-32.iso }
+          - { queue: dell-xps-13-9350-c36962, gen: "LNL", image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04c/20250801-32/somerville-noble-oem-24.04c-20250801-32.iso }
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
           name: ${{ env.CHECKBOX_PROVIDER_NAME }}
-      - uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.SAMPLE_CONSUMER_NAME }}
       - name: Build job file from template with oemscript provisioning
         run: |
           sed -e "s|REPLACE_QUEUE|${{ matrix.device.queue }}|" \
@@ -75,30 +71,138 @@ jobs:
           ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
           ${GITHUB_WORKSPACE}/job.yaml
       - name: Submit testflinger job
+        id: submit
+        continue-on-error: true
         uses: canonical/testflinger/.github/actions/submit@main
         with:
           poll: true
           job-path: ${{ github.workspace }}/job.yaml
-  tag:
-    name: Push tag for revision
-    needs: testflinger-validation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the source
-        uses: actions/checkout@v6
-      - name: Create and push tag for revision
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          client-id: ${{ secrets.TESTFLINGER_CLIENT_ID }}
+          secret-key: ${{ secrets.TESTFLINGER_SECRET_KEY }}
+      - name: Download checkbox artifacts
+        id: artifacts
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          # Download the job artifacts with retry logic
+          for attempt in {1..10}; do
+            echo "Attempt $attempt: Downloading artifacts..."
+            if testflinger artifacts ${{ steps.submit.outputs.id }}; then
+              echo "Successfully downloaded artifacts"
+              break
+            else
+              if [ $attempt -eq 10 ]; then
+                echo "Failed to download artifacts after 10 attempts"
+                exit 1
+              fi
+              echo "Failed to download artifacts, retrying in 60 seconds..."
+              sleep 60
+            fi
+          done
+          tar -xzf artifacts.tgz
+
+          # Check if any .tar.xz files exist
+          if ! ls artifacts/*.tar.xz 1> /dev/null 2>&1; then
+            echo "Error: No .tar.xz files found in artifacts/"
+            ls -la artifacts/
+            exit 1
+          fi
+
+          # Extract submission.json from each tarball.
+          #
+          # This is necessary because the test plan is run twice:
+          # - Once on the original OEM image
+          # - Once after upgrading all apt packages and rebooting
+          #
+          # The test observer uploader action cannot account for multiple
+          # submissions in a single run, so we need to extract them here and
+          # upload them separately.
+          #
+          queue="${{ matrix.device.queue }}"
+          mkdir -p "extracted-artifacts/$queue"
+          i=0
+          for file in artifacts/*.tar.xz; do
+            if [ -f "$file" ]; then
+              echo "Extracting submission.json from: $file"
+              run_dir="extracted-artifacts/$queue/run-$i"
+              mkdir -p "$run_dir"
+
+              # Extract only submission.json
+              tar -xJf "$file" submission.json -O > "$run_dir/submission.json"
+
+              # Build environment key, for example: env0=MTL-24.04.3-6.17-generic
+              kernel_ver=$(jq -r '[.system_information | .. | objects | to_entries[] | select(.key | endswith("#Kernel")) | .value] | first' "$run_dir/submission.json")
+              os_ver=$(jq -r '[.system_information | .. | objects | to_entries[] | select(.key | endswith("#Distro")) | .value] | first | match("Ubuntu ([0-9.]+)") | .captures[0].string' "$run_dir/submission.json")
+              echo "env$i=${{ matrix.device.gen }}-${os_ver}-${kernel_ver}" >> $GITHUB_OUTPUT
+
+              # Save tarball path to output
+              echo "tarball$i=$file" >> $GITHUB_OUTPUT
+
+              i=$((i + 1))
+            fi
+          done
+      - name: Upload checkbox artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: checkbox-results-${{ matrix.device.queue }}
+          path: extracted-artifacts/
+      - name: Get numeric job ID
+        id: job-id
+        run: |
+          jobs=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs)
+          # Matrix jobs include the matrix values in their name, e.g. "Testflinger Validation (dell-xps-13-9350-c36962, https://...)"
+          # We need to match based on the queue name which is unique per matrix instance
+          job_id=$(echo "$jobs" | jq -r '.jobs[] | select(.name | contains("${{ matrix.device.queue }}")) | .id')
+          echo "id=$job_id" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Checkout partner-eng-gh-actions repo
+        uses: actions/checkout@v7
+        with:
+          repository: canonical/partner-eng-gh-actions
+          ref: main
+          token: ${{ secrets.PE_BOT_PAT }}
+          path: .github/actions/partner-eng-gh-actions
+      - name: Generate TO start-payload
+        run: |
+          test_plan=$(grep "^unit = " ${GITHUB_WORKSPACE}/checkbox/bin/test-runner-automated | cut -d '=' -f2 | xargs)
           revision=$(snap info openvino-ai-plugins-gimp | grep latest/edge | cut -d "(" -f2 | cut -d ")" -f1)
           version=$(snap info openvino-ai-plugins-gimp | grep latest/edge | awk '{print $2}')
-          tag_name="${version}-rev${revision}"
-          if git ls-remote --tags origin | grep -q "refs/tags/${tag_name}"; then
-            echo "Tag ${tag_name} already exists in remote repo. Doing nothing."
-          else
-            git tag -a "${tag_name}" -m "Revision ${revision}"
-            git push origin "${tag_name}"
-          fi
+          cat <<EOF > start-payload-0.json
+          {
+            "name": "openvino-ai-plugins-gimp",
+            "version": "${version}",
+            "arch": "amd64",
+            "test_plan": "${test_plan}",
+            "environment": "${{ steps.artifacts.outputs.env0 }}",
+            "initial_status": "IN_PROGRESS",
+            "needs_assignment": false,
+            "family": "snap",
+            "revision": "${revision}",
+            "track": "latest",
+            "store": "ubuntu",
+            "branch": "",
+            "execution_stage": "edge"
+          }
+          EOF
+          jq '.environment = "${{ steps.artifacts.outputs.env1 }}"' start-payload-0.json > start-payload-1.json
+      - name: Upload first test results to test observer
+        if: steps.artifacts.outputs.tarball0 != ''
+        uses: ./.github/actions/partner-eng-gh-actions/.github/actions/test-observer-uploader
+        with:
+          results_type: checkbox
+          owner: kobuk
+          start_test_api_payload: start-payload-0.json
+          ci_link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ steps.job-id.outputs.id }}#pre-upgrade
+          results: ${{ steps.artifacts.outputs.tarball0 }}
+          test_observer_url: ${{ env.TEST_OBSERVER_URL }}
+          api_key: ${{ secrets.TEST_OBSERVER_API_KEY_PRODUCTION }}
+      - name: Upload second test results to test observer
+        if: steps.artifacts.outputs.tarball1 != ''
+        uses: ./.github/actions/partner-eng-gh-actions/.github/actions/test-observer-uploader
+        with:
+          results_type: checkbox
+          owner: kobuk
+          start_test_api_payload: start-payload-1.json
+          ci_link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ steps.job-id.outputs.id }}#post-upgrade
+          results: ${{ steps.artifacts.outputs.tarball1 }}
+          test_observer_url: ${{ env.TEST_OBSERVER_URL }}
+          api_key: ${{ secrets.TEST_OBSERVER_API_KEY_PRODUCTION }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,21 +6,22 @@ on:
       - 'snap/**'
       - 'command-chain/**'
       - '.github/workflows/pull-request.yaml'
-    branches:
-      - main
-  workflow_dispatch:
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  release:
-    name: Release to latest/edge
+  build:
+    name: Build snap and run smoke tests
     runs-on: self-hosted-linux-amd64-jammy-xlarge
+    # Only run on PRs from branches in the same repository (not forks)
+    # This ensures only trusted sources can trigger this workflow
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Find and parse snapcraft.yaml
         id: snapcraft-yaml
         uses: snapcrafters/ci/parse-snapcraft-yaml@main
@@ -29,6 +30,12 @@ jobs:
         id: build
         with:
           path: ${{ steps.snapcraft-yaml.outputs.project-root }}
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: openvino-ai-plugins-gimp-${{ github.event.pull_request.head.sha || github.sha }}
+          path: ${{ steps.build.outputs.snap }}
+          retention-days: 30
       - name: Review the built snap
         uses: diddlesnaps/snapcraft-review-action@v1
         with:
@@ -40,11 +47,3 @@ jobs:
         shell: bash
         run: |
           sudo snap install --dangerous "${{ steps.build.outputs.snap }}"
-      - name: Release to latest/edge
-        id: publish
-        shell: bash
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_PE_BOT }}
-          SNAP_FILE: ${{ steps.build.outputs.snap }}
-        run: |
-          snapcraft upload "$SNAP_FILE" --release=latest/edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,117 @@
+name: Release
+
+on:
+  push:
+    paths:
+      - 'snap/**'
+      - 'command-chain/**'
+      - '.github/workflows/release.yaml'
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: Release to latest/edge
+    runs-on: self-hosted-linux-amd64-jammy-xlarge
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v7
+      - name: Find and parse snapcraft.yaml
+        id: snapcraft-yaml
+        uses: snapcrafters/ci/parse-snapcraft-yaml@main
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+        with:
+          path: ${{ steps.snapcraft-yaml.outputs.project-root }}
+      - name: Review the built snap
+        uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: ${{ steps.snapcraft-yaml.outputs.classic }}
+          plugs: ${{ steps.snapcraft-yaml.outputs.plugs-file }}
+          slots: ${{ steps.snapcraft-yaml.outputs.slots-file }}
+      - name: Release to latest/edge
+        id: publish
+        shell: bash
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_PE_BOT }}
+          SNAP_FILE: ${{ steps.build.outputs.snap }}
+        run: |
+          snapcraft upload "$SNAP_FILE" --release=latest/edge
+  tag:
+    name: Push tag for revision
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+      version: ${{ steps.tag.outputs.version }}
+      created: ${{ steps.tag.outputs.created }}
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v7
+      - name: Create and push tag for revision
+        id: tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          revision=$(snap info openvino-ai-plugins-gimp | grep latest/edge | cut -d "(" -f2 | cut -d ")" -f1)
+          version=$(snap info openvino-ai-plugins-gimp | grep latest/edge | awk '{print $2}')
+          tag_name="${version}-rev${revision}"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if git ls-remote --tags origin | grep -q "refs/tags/${tag_name}"; then
+            echo "Tag ${tag_name} already exists in remote repo. Doing nothing."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            git tag -a "${tag_name}" -m "Revision ${revision}"
+            git push origin "${tag_name}"
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+  github-release:
+    name: Create GitHub release
+    needs: tag
+    if: needs.tag.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Create GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.tag.outputs.tag_name }}
+          VERSION: ${{ needs.tag.outputs.version }}
+          UPSTREAM_REPO: intel/openvino-ai-plugins-gimp
+        run: |
+          # Find existing releases named "${VERSION}-<n>" to determine the counter.
+          existing=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+            --jq "[.[] | select(.name | startswith(\"${VERSION}-\"))]")
+          n=$(echo "$existing" | jq 'length')
+
+          release_name="${VERSION}-${n}"
+
+          if [ "$n" -eq 0 ]; then
+            body="New upstream release. See https://github.com/${UPSTREAM_REPO}/releases for details."
+          else
+            prev_tag=$(echo "$existing" | jq -r 'sort_by(.created_at) | last | .tag_name')
+            body="Changes since the previous release: https://github.com/${GITHUB_REPOSITORY}/compare/${prev_tag}...${TAG_NAME}"
+          fi
+
+          gh release create "${TAG_NAME}" \
+            --title "${release_name}" \
+            --notes "${body}"

--- a/.github/workflows/upstream-release-check.yaml
+++ b/.github/workflows/upstream-release-check.yaml
@@ -1,0 +1,143 @@
+name: Upstream release check
+
+# Opens a single pull request when a new openvino-ai-plugins-gimp upstream
+# release exists AND the openvino major version it depends on matches an existing
+# stable track of the openvino-toolkit-2404 content snap. The PR bumps both the
+# source-tag and the content-snap year track in snap/snapcraft.yaml together.
+#
+# If a new release needs an openvino major that has no matching stable track yet,
+# no PR is opened (a warning is logged) so the snap never points at a track that
+# cannot supply the openvino version the plugin depends on.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  UPSTREAM_REPO: intel/openvino-ai-plugins-gimp
+  CONTENT_SNAP: openvino-toolkit-2404
+  SNAPCRAFT_YAML: snap/snapcraft.yaml
+
+jobs:
+  upstream-release:
+    name: Open PR for a matching upstream release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Determine whether an update is due
+        id: check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Highest semver-like tag published upstream.
+          latest_tag="$(gh api --paginate "repos/${UPSTREAM_REPO}/tags" --jq '.[].name' \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)"
+          echo "Latest upstream tag: ${latest_tag}"
+
+          # Tag currently pinned in snapcraft.yaml.
+          current_tag="$(sed -nE 's/^[[:space:]]*source-tag:[[:space:]]*(\S+).*/\1/p' "${SNAPCRAFT_YAML}" | head -n1)"
+          echo "Current source-tag: ${current_tag}"
+
+          if [[ "${latest_tag}" == "${current_tag}" ]]; then
+            echo "No new upstream release."
+            echo "update=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # openvino version the new release depends on. The pin has lived in
+          # requirements.txt (<= 3.2.1) and in setup.py's install_requires
+          # (>= 3.3.0), so check both and take the first match.
+          openvino_version=""
+          for dep_file in requirements.txt setup.py; do
+            dep_url="https://raw.githubusercontent.com/${UPSTREAM_REPO}/${latest_tag}/${dep_file}"
+            content="$(curl -fsSL "${dep_url}" || true)"
+            [[ -z "${content}" ]] && continue
+            openvino_version="$(grep -oE 'openvino[[:space:]]*[=<>~!]+[[:space:]]*[0-9]+(\.[0-9]+)*' <<< "${content}" \
+              | head -n1 | grep -oE '[0-9]+(\.[0-9]+)*' || true)"
+            [[ -n "${openvino_version}" ]] && break
+          done
+          if [[ -z "${openvino_version}" ]]; then
+            echo "::error::Could not determine the pinned openvino version for ${latest_tag}"
+            exit 1
+          fi
+          openvino_major="${openvino_version%%.*}"
+          echo "Upstream ${latest_tag} depends on openvino ${openvino_version} (major ${openvino_major})"
+
+          # Numeric stable tracks available for the content snap.
+          tracks="$(curl -fsSL -H 'Snap-Device-Series: 16' \
+            "https://api.snapcraft.io/v2/snaps/info/${CONTENT_SNAP}" \
+            | python3 -c 'import sys, json; d = json.load(sys.stdin); print("\n".join(sorted({c["channel"]["track"] for c in d["channel-map"] if c["channel"]["risk"] == "stable" and c["channel"]["track"].isdigit()})))')"
+          echo "Available stable tracks:"
+          echo "${tracks}"
+
+          if ! grep -qx "${openvino_major}" <<< "${tracks}"; then
+            echo "::warning::Upstream ${latest_tag} needs openvino major ${openvino_major}, but ${CONTENT_SNAP} has no matching stable track yet. No PR opened."
+            echo "update=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          {
+            echo "update=true"
+            echo "latest_tag=${latest_tag}"
+            echo "openvino_version=${openvino_version}"
+            echo "openvino_major=${openvino_major}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Apply the bumps to snapcraft.yaml
+        if: steps.check.outputs.update == 'true'
+        shell: bash
+        env:
+          LATEST_TAG: ${{ steps.check.outputs.latest_tag }}
+          OPENVINO_MAJOR: ${{ steps.check.outputs.openvino_major }}
+        run: |
+          set -euo pipefail
+          sed -i -E "s|^([[:space:]]*source-tag:[[:space:]]*).*|\1${LATEST_TAG}|" "${SNAPCRAFT_YAML}"
+          sed -i -E "s|(${CONTENT_SNAP}/)[0-9]+(/stable)|\1${OPENVINO_MAJOR}\2|" "${SNAPCRAFT_YAML}"
+          git --no-pager diff -- "${SNAPCRAFT_YAML}"
+
+      - name: Open the pull request
+        if: steps.check.outputs.update == 'true'
+        # Uses the default GITHUB_TOKEN (via the permissions block above). Note:
+        # GitHub deliberately does NOT start new workflow runs for events raised
+        # by GITHUB_TOKEN, so this PR will not automatically trigger
+        # pull-request.yaml. Requires the repo setting
+        # "Allow GitHub Actions to create and approve pull requests".
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          branch: automation/upstream-${{ steps.check.outputs.latest_tag }}
+          base: main
+          delete-branch: true
+          title: "chore: update to ${{ env.UPSTREAM_REPO }} ${{ steps.check.outputs.latest_tag }}"
+          commit-message: |
+            chore: update to ${{ env.UPSTREAM_REPO }} ${{ steps.check.outputs.latest_tag }}
+
+            Bump the upstream source-tag and point the ${{ env.CONTENT_SNAP }}
+            content snap at the ${{ steps.check.outputs.openvino_major }}/stable
+            track to match the openvino ${{ steps.check.outputs.openvino_version }}
+            dependency.
+          body: |
+            Automated update triggered by a new upstream release.
+
+            - Upstream release: `${{ steps.check.outputs.latest_tag }}`
+            - openvino dependency: `${{ steps.check.outputs.openvino_version }}`
+            - Content snap track: `${{ env.CONTENT_SNAP }}/${{ steps.check.outputs.openvino_major }}/stable`
+
+            > [!NOTE]
+            > This PR was opened by CI using `GITHUB_TOKEN`, so it does not
+            > automatically trigger the checks in `pull-request.yaml`. To run
+            > them, update the PR (e.g. push a commit) or close and re-open it.
+          labels: automation

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "enabledManagers": [
+    "github-actions"
+  ]
+}


### PR DESCRIPTION
## Improve and standardize CI/CD

Overhauls CI/CD to match our other snaps, automates upstream release tracking, and adds Renovate for GitHub Actions.

### Automate upstream releases (`upstream-release-check.yaml`)
- Weekly check that opens a PR when a new `intel/openvino-ai-plugins-gimp` release exists **and** the openvino major it needs has a matching `openvino-toolkit-2404` stable track.
- Bumps the `source-tag` and content-snap track together in one PR; skips (warns only) if no matching track exists.
- Reads the openvino pin from `requirements.txt` or `setup.py`; uses the default `GITHUB_TOKEN` (no PAT).

### Track Action versions (`renovate.json`)
- Renovate scoped to the `github-actions` manager, covering tag- and SHA-pinned actions.

### Standardize pipeline
- **`pull-request.yaml`**: build-only (build, review, install, upload artifact) with a fork guard.
- **`release.yaml`** (new): release to `latest/edge` on push to `main`, then tag the revision and cut a GitHub release.
- **`integration-tests.yaml`**: runs after Release completes and uploads results to Test Observer (pre- and post-upgrade).
- **`testflinger/job-def.yaml`**: runs the tests twice — before and after an `apt upgrade` + reboot.

### New secrets required
`TESTFLINGER_CLIENT_ID`, `TESTFLINGER_SECRET_KEY`, `PE_BOT_PAT`, `TEST_OBSERVER_API_KEY_PRODUCTION` (plus existing `SNAP_STORE_PE_BOT`).